### PR TITLE
[FEAT] Change erase command parameter (end lba -> size)

### DIFF
--- a/SSD/CommandChecker.cpp
+++ b/SSD/CommandChecker.cpp
@@ -165,7 +165,7 @@ void WriteCommand::execute()
 void EraseCommand::execute()
 {
 	CommandBuffer buffer;
-	BufferCommand cmd{ 'E', __lba, __lba + __size - 1 };
+	BufferCommand cmd{ 'E', __lba, __size};
 	buffer.enqueue(cmd);
 }
 


### PR DESCRIPTION
🔍 개요,
Erase Command의 second data 항목 변경

✅ 작업 내용,
Erase Command의 second data 항목이 endLba 값에서 size 값으로 변경함

⚠️ 의존성 (참고 사항),
CommandBuffer 내 erase 처리 함수들과 연관

✅테스트 결과
![캡처](https://github.com/user-attachments/assets/0e0a6b2d-6aac-488f-9f38-0451fb141831)

