### PR TITLE
[FIX] FastRead erase range fix and add constructor/desctuctor for buffer txt files

### DIFF
--- a/SSD/commandBuffer.h
+++ b/SSD/commandBuffer.h
@@ -28,6 +28,9 @@ public:
         MAX_BUFFER_SIZE = 5,
     };
 
+    CommandBuffer();
+    ~CommandBuffer();
+
     // singleton structure
     static CommandBuffer& getInstance() {
         static CommandBuffer instance;
@@ -62,7 +65,7 @@ private:
     std::string removeTxt(std::string& token);
     BufferCommand getCommandFromFile(std::string fileName);
     void makeEmptyFiles(std::string& baseDir);
-    bool readinbuffer(unsigned int lba, unsigned int& value);
+    bool fastRead(unsigned int lba, unsigned int& value);
     void optimizeCMD();
 
     std::vector<BufferCommand> buffer;


### PR DESCRIPTION
🔍 개요,
commandBuffer class 개선 및 오류 수정

✅ 작업 내용,
- readinbuffer => fastRead 함수명 변경 (Algorithm)
- CommandBuffer 생성자/소멸자 활용
- 생성자 : initializeCommandBuffer() 호출하여 buffer/*.txt 파일 vector 저장
- 소멸자 : command 처리 및 algorithm 적용 후 buffer contents를 buffer/*txt 로 export

⚠️ 의존성 (참고 사항),
내부 수정으로 의존성 없음

✅ Test Result
![캡처](https://github.com/user-attachments/assets/d4c2ac84-7d4b-4888-878b-ef3e0b303631)
