### PR TITLE
[FIX] eraseAlgorithm range bug fix

### DIFF
--- a/SSD/commandBuffer.cpp
+++ b/SSD/commandBuffer.cpp
@@ -266,10 +266,12 @@ void CommandBuffer::eraseAlgorithm() {
 	std::vector<BufferCommand> result;
 
 	for (auto it = buffer.rbegin(); it != buffer.rend(); ++it) {
+		uint start = it->firstData;
+		uint end = it->firstData + it->secondData - 1;
 		bool overlaps = false;
 		int overlapCnt = 0;
 		if (it->op == 'E') {
-			for (uint addr = it->firstData; addr <= it->secondData + it->firstData - 1 ; ++addr) {
+			for (uint addr = start; addr <= end; ++addr) {
 				if (affectedAddresses.count(addr)) {
 					overlapCnt++;
 				}
@@ -279,7 +281,7 @@ void CommandBuffer::eraseAlgorithm() {
 			}
 
 			if (!overlaps) {
-				for (uint addr = it->firstData; addr <= it->secondData; ++addr) {
+				for (uint addr = start; addr <= end; ++addr) {
 					affectedAddresses.insert(addr);
 				}
 				result.push_back(*it);

--- a/SSD/commandBuffer_Test.cpp
+++ b/SSD/commandBuffer_Test.cpp
@@ -71,7 +71,7 @@ TEST_F(CmdBufferFixture, FilesCreatedCorrectly) {
     }
 }
 
-TEST_F(CmdBufferFixture, full2) {
+TEST_F(CmdBufferFixture, full1) {
     std::vector<BufferCommand> write_commands = { {CMD_WRITE, 1, 0x11111111} , {CMD_WRITE, 2, 0x22222222} };
 
     for (auto c : write_commands) {
@@ -82,6 +82,23 @@ TEST_F(CmdBufferFixture, full2) {
     EXPECT_EQ('W', ret.op);
     EXPECT_EQ(1, ret.firstData);
     EXPECT_EQ(0x11111111, ret.secondData);
+}
+
+
+TEST_F(CmdBufferFixture, full2) {
+    std::vector<BufferCommand> write_commands = { {CMD_WRITE, 0, 0x12345678} ,
+        {CMD_WRITE, 1, 0x23456789} ,
+        {CMD_WRITE, 2, 0x34567891},
+        {CMD_ERASE, 0, 1} };
+
+    for (auto c : write_commands) {
+        cmdBuf.enqueue(c);
+    }
+
+    BufferCommand ret = cmdBuf.getBufferIndex(0);
+    EXPECT_EQ('W', ret.op);
+    EXPECT_EQ(1, ret.firstData);
+    EXPECT_EQ(0x23456789, ret.secondData);
 }
 
 TEST_F(CmdBufferFixture, BufferInitialReadOperation) {


### PR DESCRIPTION
🔍 개요,
eraseAlgorithm range bug fix

✅ 작업 내용,
eraseAlgorithm 에 범위 설정에 버그가 있어서 의도되지 않은 data가 삭제되어서 수정 함. 
관련 UnitTest 추가 


⚠️ 의존성 (참고 사항),
해당 없음 

![image](https://github.com/user-attachments/assets/5d542edb-de0d-40fc-8201-f9e4e8a61108)

