### PR TITLE
[FIX] buffer not cleared after flush operation

### DIFF
--- a/SSD/commandBuffer.cpp
+++ b/SSD/commandBuffer.cpp
@@ -130,7 +130,7 @@ bool CommandBuffer::fastRead(unsigned int lba, unsigned int& value)
 			}
 		}
 	}
-	return true;
+	return false;
 }
 
 // Call from CommandChecker
@@ -176,6 +176,7 @@ void CommandBuffer::flush() {
 			std::exception();
 		}
 	}
+	buffer.clear();
 }
 
 void CommandBuffer::pushCMD(const BufferCommand cmd) {

--- a/SSD/commandBuffer_Test.cpp
+++ b/SSD/commandBuffer_Test.cpp
@@ -198,3 +198,20 @@ TEST_F(CmdBufferFixture, CheckMergeEraseAlgorithm) {
     EXPECT_EQ(15, ret.firstData);
     EXPECT_EQ(3, ret.secondData);
 }
+
+TEST_F(CmdBufferFixture, FlushIfBufferFull) {
+    BufferCommand command[] = {
+        {'W', 1, 0x11111111},
+        {'W', 2, 0x22222222},
+        {'W', 3, 0x33333333},
+        {'W', 4, 0x44444444},
+        {'W', 5, 0x55555555},
+        {'W', 6, 0x66666666},
+    };
+
+    for (auto each : command) {
+        cmdBuf.enqueue(each);
+    }
+
+    EXPECT_FALSE(cmdBuf.isFull());
+}


### PR DESCRIPTION
🔍 개요,
flush 및 fastRead함수 관련 오류 수정

✅ 작업 내용,
Flush 후 command 정보를 가지고 있는 buffer vector가 clear되지 않음
- 6개 이상의 command가 누적되는 문제

fastRead 함수 결과가 항상 true를 return하는 문제 수정

⚠️ 의존성 (참고 사항),
내부 수정으로 의존성 없음

✅ Test Result
![캡처](https://github.com/user-attachments/assets/a34984aa-fe65-4ef2-9115-e58a87ed5f8d)
