### PR TITLE
[FIX] Split read file scheme for each 'W' and 'E' command

### DIFF
--- a/SSD/commandBuffer.cpp
+++ b/SSD/commandBuffer.cpp
@@ -59,7 +59,12 @@ BufferCommand  CommandBuffer::getCommandFromFile(std::string fileName) {
 			ret.firstData = static_cast<uint32_t>(std::stoul(token));
 			break;
 		case 3:
-			ret.secondData = static_cast<uint32_t>(std::stoul(token, nullptr, 16));
+			if (ret.op == 'W') {
+				ret.secondData = static_cast<uint32_t>(std::stoul(token, nullptr, 16));
+			}
+			else if (ret.op == 'E') {
+				ret.secondData = static_cast<uint32_t>(std::stoul(token));
+			}
 			break;
 		}
 		tokenIndex++;


### PR DESCRIPTION
🔍 개요,

erase command의 txt 파일의 value값이 증가하는 문제 수정

✅ 작업 내용,

readFile 후 buffer command 생성 시 로직 변경

- Write : 16진수 변환 (address)
- Erase : 10진수 변환 (size)

⚠️ 의존성 (참고 사항),
없음

✅  테스트 결과

![캡처](https://github.com/user-attachments/assets/18b9763a-9a67-474b-8db8-5056efe5f733)

